### PR TITLE
Added SASS path parameters for svg and overlay images

### DIFF
--- a/sass/mdb/free/_carousels-basic.scss
+++ b/sass/mdb/free/_carousels-basic.scss
@@ -57,10 +57,10 @@
         height: 36px;
     }
     .carousel-control-prev-icon {
-        background-image: url(../img/svg/arrow_left.svg);
+        background-image: url("#{$svg-image-path}arrow_left.svg");
     }
     .carousel-control-next-icon {
-        background-image: url(../img/svg/arrow_right.svg);
+        background-image: url("#{$svg-image-path}arrow_right.svg");
     }
     .carousel-indicators {
         li {

--- a/sass/mdb/free/_hover-effects.scss
+++ b/sass/mdb/free/_hover-effects.scss
@@ -48,39 +48,39 @@
 
 //Overlay patterns
 .pattern-1 {
-    background: url(../img/overlays/01.png);
+    background: url("#{$overlays-image-path}01.png");
 }
 
 .pattern-2 {
-    background: url(../img/overlays/02.png);
+    background: url("#{$overlays-image-path}02.png");
 }
 
 .pattern-3 {
-    background: url(../img/overlays/03.png);
+    background: url("#{$overlays-image-path}03.png");
 }
 
 .pattern-4 {
-    background: url(../img/overlays/04.png);
+    background: url("#{$overlays-image-path}04.png");
 }
 
 .pattern-5 {
-    background: url(../img/overlays/05.png);
+    background: url("#{$overlays-image-path}05.png");
 }
 
 .pattern-6 {
-    background: url(../img/overlays/06.png);
+    background: url("#{$overlays-image-path}06.png");
 }
 
 .pattern-7 {
-    background: url(../img/overlays/07.png);
+    background: url("#{$overlays-image-path}07.png");
 }
 
 .pattern-8 {
-    background: url(../img/overlays/08.png);
+    background: url("#{$overlays-image-path}08.png");
 }
 
 .pattern-9 {
-    background: url(../img/overlays/09.png);
+    background: url("#{$overlays-image-path}09.png");
 }
 
 // Overlay masks

--- a/sass/mdb/free/data/_variables.scss
+++ b/sass/mdb/free/data/_variables.scss
@@ -13,6 +13,10 @@ $link-color: color("light-blue", "darken-1") !default;
 /*** Fonts ***/
 $roboto-font-path: "../font/roboto/" !default;
 
+/*** Images ***/
+$overlays-image-path: "../img/overlays/" !default;
+$svg-image-path: "../img/svg/" !default;
+
 /*** Typography ***/
 $off-black: rgba(0, 0, 0, 0.87) !default;
 


### PR DESCRIPTION
This allows for better SASS customization by using parameters for image paths. This resolves issue [#58](https://github.com/mdbootstrap/bootstrap-material-design/issues/58).