### PR TITLE
Adds $image-path variable to overlay images

### DIFF
--- a/sass/mdb/free/_masks.scss
+++ b/sass/mdb/free/_masks.scss
@@ -63,7 +63,7 @@ $patterns: (
 
 @each $no, $filename in $patterns {
     .pattern-#{$no} {
-        background: url('../img/overlays/#{$filename}.png');
+        background: url('#{$image-path}/overlays/#{$filename}.png');
     }
 }
 

--- a/sass/mdb/free/data/_variables.scss
+++ b/sass/mdb/free/data/_variables.scss
@@ -132,7 +132,7 @@ $footer-insta-photos-max-width: 100px;
 $footer-insta-photos-margin: 4px;
 
 // Images Path
-$image-path: '../img/';
+$image-path: '../img/' !default;
 
 // Reponsive Headings
 $responsive-headings: (


### PR DESCRIPTION
This is a PR that adds the `$image-path` variable to the overlay images paths in the SCSS files. This will help make the image paths configurable enough to be used in webpack builds.

1. Adds `!default` to `$image-path`
2. Adds `$image-path` to overlay pattern loop
3. The implementation was based on the existing implementation in `_carousel`.

For example, this will enable a `main.scss` file to exist with:

```
$roboto-font-path: "~mdbootstrap/font/roboto/";
$image-path: "~mdbootstrap/img/";

@import "~mdbootstrap/sass/mdb.scss";
```

And for Webpack to correctly be able to load the `url(...)` image assets successfully.

---

There was a previous PR that made the SVG and overlay images use separate paths. That may be more desirable than this, actually. It was not accepted however.