### PR TITLE
$image-path not used in _masks.scss, breaks sass compile

### DIFF
--- a/sass/mdb/free/_carousel-basic.scss
+++ b/sass/mdb/free/_carousel-basic.scss
@@ -6,10 +6,10 @@
         height: 36px;
     }
     .carousel-control-prev-icon {
-        background-image: url(#{$image-path}/svg/arrow_left.svg);
+        background-image: url(#{$image-path}svg/arrow_left.svg);
     }
     .carousel-control-next-icon {
-        background-image: url(#{$image-path}/svg/arrow_right.svg);
+        background-image: url(#{$image-path}svg/arrow_right.svg);
     }
     .carousel-indicators {
         li {

--- a/sass/mdb/free/_masks.scss
+++ b/sass/mdb/free/_masks.scss
@@ -63,7 +63,7 @@ $patterns: (
 
 @each $no, $filename in $patterns {
     .pattern-#{$no} {
-        background: url('../img/overlays/#{$filename}.png');
+        background: url('{$image-path}overlays/#{$filename}.png');
     }
 }
 


### PR DESCRIPTION
Fix for #106 