### PR TITLE
$image-path can now be overridden, added to _masks.scss

### DIFF
--- a/sass/mdb/free/_masks.scss
+++ b/sass/mdb/free/_masks.scss
@@ -63,7 +63,7 @@ $patterns: (
 
 @each $no, $filename in $patterns {
   .pattern-#{$no} {
-    background: url('../img/overlays/#{$filename}.png');
+    background: url('#{$image-path}/overlays/#{$filename}.png');
   }
 }
 

--- a/sass/mdb/free/data/_variables.scss
+++ b/sass/mdb/free/data/_variables.scss
@@ -132,7 +132,7 @@ $footer-insta-photos-max-width: 100px;
 $footer-insta-photos-margin: 4px;
 
 // Images Path
-$image-path: '../img/';
+$image-path: '../img/' !default;
 
 // Reponsive Headings
 $responsive-headings: (


### PR DESCRIPTION
I know there's already a PR (#107). but that hasn't been merged, and is now in conflict with the repo.

Fixes #106 again...

I couldn't build the sass files without overriding the `$image-path` variable. Now it's set to default.
Also added the variable to `_masks.scss` file.

Paths can now both be set in a custom sass file in your project, before loading the mdbootstrap library:

```
$roboto-font-path: "~mdbootstrap/font/roboto/";
$image-path:"~mdbootstrap/img/";
```