### PR TITLE
Fixed so page dont scroll when modal opens

### DIFF
--- a/css/mdb.css
+++ b/css/mdb.css
@@ -6678,6 +6678,7 @@ button:focus {
 
 body.modal-open {
   padding-right: 0 !important;
+  overscroll-behavior: contain;
   overflow: auto; }
 
 body.scrollable {


### PR DESCRIPTION
It the page would have a scroll bar and I open modal and scrolled on the mouse it would scroll the page under the modal.