### PR TITLE
Update _colors.scss - added classes for material text colors

### DIFF
--- a/scss/core/_colors.scss
+++ b/scss/core/_colors.scss
@@ -715,6 +715,9 @@ $material-colors: map-merge((
   .#{$color_name} {
     background-color: $color !important;
   }
+  .#{$color_name}-text {
+    color: $color !important;
+  }
 }
 
 // Social colors


### PR DESCRIPTION
Added classes for text color based on material colors in `$material-colors`
For example: `.primary-color-text`, `.secondary-color-dark-text`, etc