### PR TITLE
Fixes free version nav-tab color overrides for modal color styling

### DIFF
--- a/scss/free/_modals.scss
+++ b/scss/free/_modals.scss
@@ -263,14 +263,14 @@ body {
       width: $modal-width;
     }
   }
-}
-.nav-tabs {
-  border-radius: $md-card-border-radius;
-  .nav-item {
-    .nav-link {
-      border-radius: $md-card-border-radius;
-      background-color: inherit;
-      color: $white-base;
+  .nav-tabs {
+    border-radius: $md-card-border-radius;
+    .nav-item {
+      .nav-link {
+        border-radius: $md-card-border-radius;
+        background-color: inherit;
+        color: $white-base;
+      }
     }
   }
 }


### PR DESCRIPTION
4.5.3 attempted to correct color styling in nav-tabs for modals in the
free version, but was improperly scoped