### PR TITLE
waves fix

### DIFF
--- a/js/modules/waves.js
+++ b/js/modules/waves.js
@@ -456,8 +456,8 @@
         }
     }
 
-    Waves.init = function(options) {
-        var body = document.body;
+    Waves.init = function(options, w) {
+        var body = (w !== undefined) ? w.document.body : document.body;
 
         options = options || {};
 


### PR DESCRIPTION
This fix enable attach waves effect to elements, that were dynamically created in new window. A simple example:
```javascript
var w = window.open();
var pageContent = ...
$(w.document.body).append(pageContent);
var buttons = pageContent.find('.btn:not(.btn-flat), .btn-floating');
Waves.attach(buttons, ['waves-light']);
Waves.init({}, w);
```
What do you think about this fix?